### PR TITLE
Feat: 인증 메일 로직 Redis로 변경

### DIFF
--- a/src/main/java/com/example/springbootboard/config/RedisConfig.java
+++ b/src/main/java/com/example/springbootboard/config/RedisConfig.java
@@ -1,0 +1,39 @@
+package com.example.springbootboard.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+    @Value("${spring.redis.host}")
+    private String host;
+
+    @Value("${spring.redis.port}")
+    private int port;
+
+    /**
+     * 내장 혹은 외부의 Redis를 연결
+     */
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(host, port);
+    }
+
+    /**
+     * RedisConnection 에서 넘겨준 byte 값 객체 직렬화
+     */
+    @Bean
+    public RedisTemplate<?, ?> redisTemplate() {
+        RedisTemplate<byte[], byte[]> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+        return redisTemplate;
+    }
+}

--- a/src/main/java/com/example/springbootboard/controller/Rest/v1/DummyDataController.java
+++ b/src/main/java/com/example/springbootboard/controller/Rest/v1/DummyDataController.java
@@ -7,6 +7,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import javax.transaction.Transactional;
 import java.util.UUID;
 
 @RestController
@@ -15,8 +16,9 @@ import java.util.UUID;
 public class DummyDataController {
 
     private final EmailAuthRepository emailAuthRepository;
-    
+
     @GetMapping("/insertAuthMail")
+    @Transactional
     public String insert_100_000_AuthMail() {
 
         for (int i = 0; i < 100_000; i++) {
@@ -26,5 +28,4 @@ public class DummyDataController {
         }
         return "done!";
     }
-
 }

--- a/src/main/java/com/example/springbootboard/controller/Rest/v1/EmailController.java
+++ b/src/main/java/com/example/springbootboard/controller/Rest/v1/EmailController.java
@@ -28,8 +28,6 @@ public class EmailController {
             @ApiResponse(code = 500, message = "서버 오류")
     })
     public ResponseDTO<String> sendEmail(@RequestBody UserEmailRequestDTO userEmailRequestDTO) throws Exception {
-        System.out.println("userEmail = " + userEmailRequestDTO.getUserEmail());
-
         emailService.sendSimpleMessage(userEmailRequestDTO);
 
         return ResponseDTO.of(200, "Send Email SUCCESS", "OK");
@@ -44,7 +42,6 @@ public class EmailController {
             @ApiResponse(code = 500, message = "서버 오류")
     })
     public ResponseDTO<String> verifyEmail(@RequestBody UserEmailRequestDTO userEmailDTO) {
-        System.out.println("verify 들어옴 = ");
         if (emailService.isVerifiedCode(userEmailDTO)) {
             return ResponseDTO.of(200, "Verification SUCCESS", "OK");
         }

--- a/src/main/java/com/example/springbootboard/controller/UserController.java
+++ b/src/main/java/com/example/springbootboard/controller/UserController.java
@@ -39,8 +39,6 @@ public class UserController {
             return "redirect:login?error";
         }
         userService.signUpUser(userRequestDTO);
-
-
         return "redirect:login";
     }
 
@@ -55,7 +53,6 @@ public class UserController {
 
     @GetMapping("/logout")
     public String performLogout() {
-        System.out.println("들어옴?");
         session.removeAttribute("user");
         return "redirect:/";
     }

--- a/src/main/java/com/example/springbootboard/service/Impl/EmailServiceRedisImpl.java
+++ b/src/main/java/com/example/springbootboard/service/Impl/EmailServiceRedisImpl.java
@@ -44,7 +44,8 @@ public class EmailServiceRedisImpl implements EmailService {
         String authCode = createKey();
         String userEmail = userEmailRequestDTO.getUserEmail();
 
-        redisUtil.setDataExpire(userEmail, authCode, (long) (5 * 60) + 30);
+        // Redis TTL과 화면단 타이머가 5초 차이 발생 -> duration +5초 
+        redisUtil.setDataExpire(userEmail, authCode, (long) (5 * 60) + 5);
 
         sendMail(userEmail, authCode);
     }

--- a/src/main/java/com/example/springbootboard/utils/RedisUtil.java
+++ b/src/main/java/com/example/springbootboard/utils/RedisUtil.java
@@ -1,0 +1,52 @@
+package com.example.springbootboard.utils;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+
+@Service
+@RequiredArgsConstructor
+public class RedisUtil {
+
+    // StringRedisTemplate 은 RedisTemplate<String, String> 를 extends한 Redis의 Build-in Class 
+    private final StringRedisTemplate redisTemplate;
+
+    // key를 통해 value 리턴
+    public String getData(String key) {
+        ValueOperations<String, String> valueOperations = redisTemplate.opsForValue();
+        return valueOperations.get(key);
+    }
+
+    public void setData(String key, String value) {
+        ValueOperations<String, String> valueOperations = redisTemplate.opsForValue();
+        valueOperations.set(key, value);
+    }
+
+    // 유효 시간 동안 (key, value) 저장
+    public void setDataExpire(String key, String value, long durationSeconds) {
+        ValueOperations<String, String> valueOperations = redisTemplate.opsForValue();
+        Duration expireDuration = Duration.ofSeconds(durationSeconds);
+        valueOperations.set(key, value, expireDuration);
+    }
+
+    // 키값이 없을 경우에만 저장
+    public void setDataIfAbsent(String key, String value) {
+        ValueOperations<String, String> valueOperations = redisTemplate.opsForValue();
+        valueOperations.setIfAbsent(key, value);
+    }
+
+    public void setDataIfAbsentExpire(String key, String value, long durationSeconds) {
+        ValueOperations<String, String> valueOperations = redisTemplate.opsForValue();
+        Duration expireDuration = Duration.ofSeconds(durationSeconds);
+        valueOperations.setIfAbsent(key, value, expireDuration);
+    }
+
+
+    // 삭제
+    public void deleteData(String key) {
+        redisTemplate.delete(key);
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,7 +1,7 @@
 server.port=9090
 
 # profile managing
-spring.profiles.include=db,s3,smtp,aop
+spring.profiles.include=db,smtp,aop
 
 # JSP
 spring.mvc.view.prefix=/WEB-INF/views/
@@ -13,7 +13,10 @@ spring.devtools.livereload.enabled=true
 # SpringFox Swagger 
 spring.mvc.pathmatch.matching-strategy=ant_path_matcher
 
-# logging level
+# Logging
+logging.pattern.dateformat=yyyy-MM-dd HH:MM:ss
+#logging.pattern.console=
+## Logging level
 logging.level.root=info
 #logging.level.root=warn
 #logging.level.root=error


### PR DESCRIPTION
### 코드 작성 이유
인증 코드의 경우 5분간만 필요한 데이터이기에 DB에 영구 저장하지 않고 Redis에 잠깐 저장하기로 결정
<br>

### 상세 사항
- 인증 로직 Redis로 변경
    - DB Table, DB 이용 로직은 남겨둔 채 `EmailServiceRedisImpl` 클래스만 추가
    - 해당 Bean을 주입하기 위해 `@Primary` 어노테이션 활용
- Log TimeFormat 변경 (ms 제거) 
- DummyDataController에 `@Transactional` 추가
<br>

### 참고 사항

<br>

### 다음 작업
- 이미 인증 메일이 간 상태일 경우 로직 추가할 예정
<br>

#### CheckList

- [x] MVC 패턴 준수
- [x] 코딩 컨벤션 준수
- [x] 커밋 컨벤션 준수
