### PR TITLE
Feat: 상세 페이지 조회수 구현

### DIFF
--- a/src/main/java/com/example/springbootboard/SpringBootBoardApplication.java
+++ b/src/main/java/com/example/springbootboard/SpringBootBoardApplication.java
@@ -2,9 +2,9 @@ package com.example.springbootboard;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
-@EnableJpaAuditing
+@EnableScheduling
 @SpringBootApplication
 public class SpringBootBoardApplication {
 

--- a/src/main/java/com/example/springbootboard/controller/PostController.java
+++ b/src/main/java/com/example/springbootboard/controller/PostController.java
@@ -3,6 +3,9 @@ package com.example.springbootboard.controller;
 import com.example.springbootboard.data.dto.PostRequestDTO;
 import com.example.springbootboard.data.dto.PostResponseDTO;
 import com.example.springbootboard.service.PostService;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -21,7 +24,7 @@ import org.springframework.web.multipart.MultipartFile;
 @RequiredArgsConstructor
 public class PostController {
     private final PostService postService;
-    
+
     @GetMapping("/list")
     public String getPostList(Model model, @RequestParam String teamName, @RequestParam(required = false, defaultValue = "") String search, Pageable pageable) {
         Page<PostResponseDTO> postResponseDTOList = null;
@@ -76,8 +79,17 @@ public class PostController {
     }
 
     @GetMapping("/detail")
-    public String getWritePostPage(Model model, @RequestParam Long postId) {
+    @ApiOperation(value = "상세 페이지", notes = "")
+    @ApiResponses({
+            @ApiResponse(code = 200, message = "성공"),
+            @ApiResponse(code = 401, message = "인증 실패"),
+            @ApiResponse(code = 404, message = "사용자 없음"),
+            @ApiResponse(code = 500, message = "서버 오류")
+    })
+    public String getDetailPage(Model model, @RequestParam Long postId, @RequestParam String teamName) {
         PostResponseDTO postResponseDTO = postService.findById(postId);
+        postResponseDTO.setView(postService.incrementViewCount(postId));
+        
         model.addAttribute(postResponseDTO);
         return "boards/detailPage";
     }

--- a/src/main/java/com/example/springbootboard/controller/Rest/v1/DummyDataController.java
+++ b/src/main/java/com/example/springbootboard/controller/Rest/v1/DummyDataController.java
@@ -1,7 +1,11 @@
 package com.example.springbootboard.controller.Rest.v1;
 
 import com.example.springbootboard.data.entity.EmailAuth;
+import com.example.springbootboard.data.entity.Post;
+import com.example.springbootboard.data.entity.Team;
 import com.example.springbootboard.data.repository.EmailAuthRepository;
+import com.example.springbootboard.data.repository.PostRepository;
+import com.example.springbootboard.data.repository.TeamRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -16,8 +20,10 @@ import java.util.UUID;
 public class DummyDataController {
 
     private final EmailAuthRepository emailAuthRepository;
+    private final PostRepository postRepository;
+    private final TeamRepository teamRepository;
 
-    @GetMapping("/insertAuthMail")
+    @GetMapping("/authMails/insert")
     @Transactional
     public String insert_100_000_AuthMail() {
         for (int i = 0; i < 100_000; i++) {
@@ -27,4 +33,24 @@ public class DummyDataController {
         }
         return "done!";
     }
+
+    @GetMapping("/posts/insert")
+    @Transactional
+    public String insert_10_000_posts() {
+        Team team = teamRepository.findById(1L).get();
+        for (int i = 0; i < 10_000; i++) {
+            postRepository.save(
+                    Post.builder()
+                            .postTitle(UUID.randomUUID().toString())
+                            .postContent("디도스 컨텐츠ㅋㅋㅋ")
+                            .nickname("SpringBoot")
+                            .password("asdfasdf")
+                            .userId(1L)
+                            .team(team)
+                            .build()
+            );
+        }
+        return "done!";
+    }
+
 }

--- a/src/main/java/com/example/springbootboard/data/dto/PostResponseDTO.java
+++ b/src/main/java/com/example/springbootboard/data/dto/PostResponseDTO.java
@@ -22,6 +22,7 @@ public class PostResponseDTO {
     private Long userId;
     private String nickname;
     private String teamName;
+    private Long view;
 
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;

--- a/src/main/java/com/example/springbootboard/data/dto/RedisPostDTO.java
+++ b/src/main/java/com/example/springbootboard/data/dto/RedisPostDTO.java
@@ -1,0 +1,18 @@
+package com.example.springbootboard.data.dto;
+
+import lombok.*;
+
+@Getter
+@Setter
+@ToString
+@AllArgsConstructor
+@NoArgsConstructor
+@EqualsAndHashCode
+@Builder
+public class RedisPostDTO {
+    /**
+     * Redis의 postId::{postId}에 해당 DTO를 넣는다.
+     */
+    private Long view;
+
+}

--- a/src/main/java/com/example/springbootboard/data/entity/Post.java
+++ b/src/main/java/com/example/springbootboard/data/entity/Post.java
@@ -36,6 +36,9 @@ public class Post extends BaseEntity {
     @Column(name = "password")
     private String password;
 
+    @Column(name = "view", columnDefinition = "BIGINT DEFAULT 0")
+    private Long view;
+
     @ManyToOne
     @JoinColumn(name = "team_id")
     private Team team;
@@ -46,4 +49,8 @@ public class Post extends BaseEntity {
     @OneToMany(mappedBy = "post", cascade = CascadeType.PERSIST)
     private List<Comment> comments = new ArrayList<>();
 
+    @PrePersist
+    public void prePersist() {
+        this.view = this.view == null ? 0 : this.view;
+    }
 }

--- a/src/main/java/com/example/springbootboard/global/config/JpaAuditingConfiguration.java
+++ b/src/main/java/com/example/springbootboard/global/config/JpaAuditingConfiguration.java
@@ -1,0 +1,9 @@
+package com.example.springbootboard.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditingConfiguration {
+}

--- a/src/main/java/com/example/springbootboard/global/config/RedisConfig.java
+++ b/src/main/java/com/example/springbootboard/global/config/RedisConfig.java
@@ -6,6 +6,8 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
@@ -33,7 +35,10 @@ public class RedisConfig {
         RedisTemplate<byte[], byte[]> redisTemplate = new RedisTemplate<>();
         redisTemplate.setConnectionFactory(redisConnectionFactory());
         redisTemplate.setKeySerializer(new StringRedisSerializer());
-        redisTemplate.setValueSerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+        redisTemplate.setHashKeySerializer(new StringRedisSerializer());
+        redisTemplate.setHashValueSerializer(new Jackson2JsonRedisSerializer<>(Object.class));
+        redisTemplate.afterPropertiesSet();
         return redisTemplate;
     }
 }

--- a/src/main/java/com/example/springbootboard/global/scheduled/RedisScheduled.java
+++ b/src/main/java/com/example/springbootboard/global/scheduled/RedisScheduled.java
@@ -1,0 +1,21 @@
+package com.example.springbootboard.global.scheduled;
+
+import com.example.springbootboard.service.PostService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RedisScheduled {
+    private final PostService postService;
+
+    @Transactional
+    @Scheduled(cron = "0 0 0 * * ?") // 매일 0시에
+    public void syncViewCountWithDB() {
+        postService.syncViewCount();
+    }
+}

--- a/src/main/java/com/example/springbootboard/global/utils/RedisStringUtil.java
+++ b/src/main/java/com/example/springbootboard/global/utils/RedisStringUtil.java
@@ -9,7 +9,7 @@ import java.time.Duration;
 
 @Service
 @RequiredArgsConstructor
-public class RedisUtil {
+public class RedisStringUtil {
 
     // StringRedisTemplate 은 RedisTemplate<String, String> 를 extends한 Redis의 Build-in Class 
     private final StringRedisTemplate redisTemplate;
@@ -43,7 +43,6 @@ public class RedisUtil {
         Duration expireDuration = Duration.ofSeconds(durationSeconds);
         return valueOperations.setIfAbsent(key, value, expireDuration);
     }
-
 
     // 삭제
     public void deleteData(String key) {

--- a/src/main/java/com/example/springbootboard/service/Impl/EmailServiceRedisImpl.java
+++ b/src/main/java/com/example/springbootboard/service/Impl/EmailServiceRedisImpl.java
@@ -55,9 +55,10 @@ public class EmailServiceRedisImpl implements EmailService {
 
     private void sendMail(String userEmail, String authCode) throws Exception {
 
-        String subject = "스프링 보드 가입 인증 메일";
+        String serviceName = "Spring-Boards";
+        String subject = serviceName + " 가입 인증 메일";
         String text = "<div style='margin:20px;'>" +
-                "<h1> 안녕하세요 Spring-Board입니다.</h1><br>" +
+                "<h1> 안녕하세요 " + serviceName + " 입니다.</h1><br>" +
                 "<p>아래 코드를 복사해 입력해주세요<p><br>" +
                 "<p>감사합니다.<p><br>" +
                 "<div align='center' style='border:1px solid black); font-family:verdana');>" +
@@ -68,7 +69,7 @@ public class EmailServiceRedisImpl implements EmailService {
         message.addRecipients(RecipientType.TO, userEmail);// 보내는 대상
         message.setSubject(subject);// 제목
         message.setText(text, "utf-8", "html");// 내용
-        message.setFrom(new InternetAddress("spring-boards.io", "Spring-Boards"));// 보내는 사람
+        message.setFrom(new InternetAddress(id, serviceName));// 보내는 사람
 
         try {// 예외처리
             emailSender.send(message);

--- a/src/main/java/com/example/springbootboard/service/Impl/EmailServiceRedisImpl.java
+++ b/src/main/java/com/example/springbootboard/service/Impl/EmailServiceRedisImpl.java
@@ -1,7 +1,7 @@
 package com.example.springbootboard.service.Impl;
 
 import com.example.springbootboard.data.dto.UserEmailRequestDTO;
-import com.example.springbootboard.global.utils.RedisUtil;
+import com.example.springbootboard.global.utils.RedisStringUtil;
 import com.example.springbootboard.service.EmailService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
@@ -22,7 +22,7 @@ import java.util.Random;
 public class EmailServiceRedisImpl implements EmailService {
 
     private final JavaMailSender emailSender;
-    private final RedisUtil redisUtil;
+    private final RedisStringUtil redisUtil;
 
     @Value("${AdminMail.id}")
     private String id;

--- a/src/main/java/com/example/springbootboard/service/PostService.java
+++ b/src/main/java/com/example/springbootboard/service/PostService.java
@@ -23,4 +23,8 @@ public interface PostService {
 
     void delete(Long postId);
 
+    long incrementViewCount(Long postId);
+
+    void syncViewCount();
+
 }

--- a/src/main/webapp/WEB-INF/views/boards/deletePage.jsp
+++ b/src/main/webapp/WEB-INF/views/boards/deletePage.jsp
@@ -1,4 +1,4 @@
-<%--
+<%@ page import="java.util.Optional" %><%--
   Created by IntelliJ IDEA.
   User: chaedongim
   Date: 2023/07/14

--- a/src/main/webapp/WEB-INF/views/boards/detailPage.jsp
+++ b/src/main/webapp/WEB-INF/views/boards/detailPage.jsp
@@ -3,7 +3,8 @@
 <%@ page import="com.example.springbootboard.data.entity.Comment" %>
 <%@ page import="java.time.format.DateTimeFormatter" %>
 <%@ page import="java.text.SimpleDateFormat" %>
-<%@ page import="org.joda.time.format.DateTimeFormat" %><%--
+<%@ page import="org.joda.time.format.DateTimeFormat" %>
+<%@ page import="java.util.Optional" %><%--
   Created by IntelliJ IDEA.
   User: chaedongim
   Date: 2023/07/11
@@ -60,10 +61,12 @@
                 <span><%=postResponseDTO.getNickname()%></span>
                 <span class="mx-4" style="border-left:1px solid #bbbbbb;"></span>
                 <span><%=createdAt%></span>
+                <span class="mx-4" style="border-left:1px solid #bbbbbb;"></span>
+                <span>조회수: <%=postResponseDTO.getView()%></span>
               </p>
             </div>
             <hr>
-            <p class="postContent" style="min-height: 10rem;">
+            <p class=" postContent" style="min-height: 10rem;">
               <%=postResponseDTO.getPostContent()%>
             </p>
             <hr>

--- a/src/main/webapp/WEB-INF/views/boards/updatePostPage.jsp
+++ b/src/main/webapp/WEB-INF/views/boards/updatePostPage.jsp
@@ -1,4 +1,5 @@
-<%@ page import="com.example.springbootboard.data.dto.PostResponseDTO" %><%--
+<%@ page import="com.example.springbootboard.data.dto.PostResponseDTO" %>
+<%@ page import="java.util.Optional" %><%--
   Created by IntelliJ IDEA.
   User: chaedongim
   Date: 2023/07/11
@@ -47,6 +48,7 @@
         <div class="card-body">
           <form id="nickPwForm" class="d-flex flex-column gap-2" method="post" action="update"
                 enctype="multipart/form-data">
+            <input type="hidden" name="${_csrf.parameterName}" value="${_csrf.token}"/>
             <div class="d-flex gap-2">
               <input class="p-2 form-control" name="nickname" id="nickname" type="text" placeholder="닉네임"
                      value="<%=postResponseDTO.getNickname()%>"

--- a/src/main/webapp/WEB-INF/views/boards/writePostPage.jsp
+++ b/src/main/webapp/WEB-INF/views/boards/writePostPage.jsp
@@ -1,4 +1,5 @@
-<%@ page import="com.example.springbootboard.data.dto.PostResponseDTO" %><%--
+<%@ page import="com.example.springbootboard.data.dto.PostResponseDTO" %>
+<%@ page import="java.util.Optional" %><%--
   Created by IntelliJ IDEA.
   User: chaedongim
   Date: 2023/07/11
@@ -48,6 +49,7 @@
         <div class="card-body">
           <form id="nickPwForm" class="d-flex flex-column gap-2" method="post" action="write"
                 enctype="multipart/form-data">
+            <input type="hidden" name="${_csrf.parameterName}" value="${_csrf.token}"/>
             <div class="d-flex gap-2">
               <input class="p-2 form-control" name="nickname" id="nickname" type="text" placeholder="닉네임"
                      minlength="2"

--- a/src/main/webapp/WEB-INF/views/errors/error.jsp
+++ b/src/main/webapp/WEB-INF/views/errors/error.jsp
@@ -1,5 +1,6 @@
 <%@ page import="com.example.springbootboard.global.error.errorcode.ErrorCode" %>
-<%@ page import="com.example.springbootboard.global.error.ErrorResponse" %><%--
+<%@ page import="com.example.springbootboard.global.error.ErrorResponse" %>
+<%@ page import="java.util.Optional" %><%--
   Created by IntelliJ IDEA.
   User: chaedongim
   Date: 2023/07/17

--- a/src/main/webapp/WEB-INF/views/errors/notFound.jsp
+++ b/src/main/webapp/WEB-INF/views/errors/notFound.jsp
@@ -1,4 +1,4 @@
-<%--
+<%@ page import="java.util.Optional" %><%--
   Created by IntelliJ IDEA.
   User: chaedongim
   Date: 2023/07/12

--- a/src/main/webapp/WEB-INF/views/myPage.jsp
+++ b/src/main/webapp/WEB-INF/views/myPage.jsp
@@ -1,6 +1,7 @@
 <%@ page import="java.util.List" %>
 <%@ page import="java.util.ArrayList" %>
 <%@ page import="com.example.springbootboard.data.dto.PostResponseDTO" %>
+<%@ page import="java.util.Optional" %>
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
 <%--
   Created by IntelliJ IDEA.

--- a/src/test/java/com/example/springbootboard/controller/PostControllerTest.java
+++ b/src/test/java/com/example/springbootboard/controller/PostControllerTest.java
@@ -1,0 +1,42 @@
+package com.example.springbootboard.controller;
+
+import com.example.springbootboard.service.Impl.PostServiceImpl;
+import org.apache.catalina.security.SecurityConfig;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.context.WebApplicationContext;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+
+@WebMvcTest(PostController.class)
+@Import(SecurityConfig.class)
+public class PostControllerTest {
+
+    @Autowired
+    WebApplicationContext context;
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private PostServiceImpl postService;
+
+    @Test
+    void visitAllPosts() throws Exception {
+        // given
+        for (Long postId = 1L; postId < 100; postId++) {
+            System.out.println(postId);
+            // when
+            // then
+            mockMvc.perform(get("/posts/detail?teamName=all&postId=" + postId))
+                    // .param("teamName", "all")
+                    // .param("postId", postId.toString()))
+                    // .andExpect(status().isOk())
+                    .andReturn();
+
+        }
+    }
+}

--- a/src/test/java/com/example/springbootboard/controller/UserControllerTest.java
+++ b/src/test/java/com/example/springbootboard/controller/UserControllerTest.java
@@ -1,0 +1,4 @@
+package com.example.springbootboard.controller;
+
+public class UserControllerTest {
+}

--- a/src/test/java/com/example/springbootboard/repository/PostRepositoryTest.java
+++ b/src/test/java/com/example/springbootboard/repository/PostRepositoryTest.java
@@ -6,8 +6,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-
-import javax.transaction.Transactional;
+import org.springframework.transaction.annotation.Transactional;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 

--- a/src/test/java/com/example/springbootboard/service/impl/PostServiceImplTest.java
+++ b/src/test/java/com/example/springbootboard/service/impl/PostServiceImplTest.java
@@ -1,0 +1,30 @@
+package com.example.springbootboard.service.impl;
+
+
+import com.example.springbootboard.service.Impl.PostServiceImpl;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ExtendWith(MockitoExtension.class)
+public class PostServiceImplTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+    @Autowired
+    private PostServiceImpl postService;
+
+    @Test
+    @Transactional
+    public void syncViewCountTest() {
+        postService.syncViewCount();
+    }
+}


### PR DESCRIPTION
### 코드 작성 이유
상세 페이지의 조회수 필요
<br>

### 상세 사항
- 상세 페이지 조회수 구현 (Redis Caching)
- 캐싱 데이터 자정마다 DB update 되도록 스케쥴 구현
    - Redis의 Keys는 싱글 스레드를 점유할 수 있으므로 scan으로 구현
    - 하지만 Scan이 제대로 동작하는지 확인 필요...
- 테스트 코드 및 더미 데이터 API 작성
<br>

### 참고 사항
- 아직 테스트 코드 작성이 미숙해 학습 및 연습 필요
<br>

### 다음 작업
- 사이트 조회수
    - 일자별, 토탈
    - UserID를 식별자로 카운트 하고 싶다. (중복 제거를 위해)
    - 그럴 경우 비회원 어떻게 해야할지 고민 필요 
<br>

#### CheckList

- [x] MVC 패턴 준수
- [x] 코딩 컨벤션 준수
- [x] 커밋 컨벤션 준수
