### PR TITLE
Refactor: EmailService의 반복되는 로직 EmailUtils로 분리

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,7 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-validation</artifactId>
         </dependency>
+
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-mail</artifactId>
@@ -69,6 +70,8 @@
             <artifactId>lombok</artifactId>
             <optional>true</optional>
         </dependency>
+
+        <!--  테스트 라이브러리       -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
@@ -78,6 +81,8 @@
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-test</artifactId>
         </dependency>
+
+        <!-- JSP 라이브러리       -->
         <dependency>
             <groupId>org.apache.tomcat.embed</groupId>
             <artifactId>tomcat-embed-jasper</artifactId>

--- a/src/main/java/com/example/springbootboard/domain/emailauth/service/EmailService.java
+++ b/src/main/java/com/example/springbootboard/domain/emailauth/service/EmailService.java
@@ -3,7 +3,8 @@ package com.example.springbootboard.domain.emailauth.service;
 import com.example.springbootboard.domain.users.dto.UserEmailRequestDTO;
 
 public interface EmailService {
-    boolean isVerifiedCode(UserEmailRequestDTO userEmailRequestDTO);
 
     void sendSimpleMessage(UserEmailRequestDTO userEmailRequestDTO) throws Exception;
+
+    boolean isVerifiedCode(UserEmailRequestDTO userEmailRequestDTO);
 }

--- a/src/main/java/com/example/springbootboard/domain/emailauth/service/EmailServiceImpl.java
+++ b/src/main/java/com/example/springbootboard/domain/emailauth/service/EmailServiceImpl.java
@@ -4,29 +4,30 @@ import com.example.springbootboard.domain.emailauth.EmailAuth;
 import com.example.springbootboard.domain.emailauth.EmailAuthRepository;
 import com.example.springbootboard.domain.users.dto.UserEmailRequestDTO;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.mail.MailException;
-import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import javax.mail.Message.RecipientType;
-import javax.mail.internet.InternetAddress;
-import javax.mail.internet.MimeMessage;
 import java.util.List;
-import java.util.Random;
 
 @Service
 @RequiredArgsConstructor
 public class EmailServiceImpl implements EmailService {
 
-    private final JavaMailSender emailSender;
     private final EmailAuthRepository emailAuthRepository;
+    private final EmailUtils emailUtils;
 
-    @Value("${AdminMail.id}")
-    private String id;
-    @Value("${AdminMail.password}")
-    private String password;
+    @Override
+    @Transactional
+    public void sendSimpleMessage(UserEmailRequestDTO userEmailRequestDTO) throws Exception {
+        String authCode = emailUtils.createAuthCode();
+        String userEmail = userEmailRequestDTO.getUserEmail();
+        emailAuthRepository.save(EmailAuth.builder()
+                .userEmail(userEmail)
+                .authCode(authCode)
+                .build());
+
+        emailUtils.sendMail(userEmail, authCode);
+    }
 
     @Override
     @Transactional
@@ -38,69 +39,5 @@ public class EmailServiceImpl implements EmailService {
         }
 
         return isExists;
-    }
-
-    @Override
-    @Transactional
-    public void sendSimpleMessage(UserEmailRequestDTO userEmailRequestDTO) throws Exception {
-        String authCode = createKey();
-        String userEmail = userEmailRequestDTO.getUserEmail();
-        emailAuthRepository.save(EmailAuth.builder()
-                .userEmail(userEmail)
-                .authCode(authCode)
-                .build());
-
-        sendMail(userEmail, authCode);
-    }
-
-    private void sendMail(String userEmail, String authCode) throws Exception {
-
-        String subject = "스프링 보드 가입 인증 메일";
-        String text = "<div style='margin:20px;'>" +
-                "<h1> 안녕하세요 Spring-Board입니다.</h1><br>" +
-                "<p>아래 코드를 복사해 입력해주세요<p><br>" +
-                "<p>감사합니다.<p><br>" +
-                "<div align='center' style='border:1px solid black); font-family:verdana');>" +
-                "<h3 style='color:blue);'>회원가입 인증 코드입니다.</h3>" +
-                "<div style='font-size:130%'>CODE : <strong>" + authCode + "</strong><div><br/></div>";
-
-        MimeMessage message = emailSender.createMimeMessage();
-        message.addRecipients(RecipientType.TO, userEmail);// 보내는 대상
-        message.setSubject(subject);// 제목
-        message.setText(text, "utf-8", "html");// 내용
-        message.setFrom(new InternetAddress("spring-boards.io", "Spring-Boards"));// 보내는 사람
-
-        try {// 예외처리
-            emailSender.send(message);
-            System.out.println("생성된 AuthCode : " + authCode);
-        } catch (MailException es) {
-            es.printStackTrace();
-            throw new IllegalArgumentException();
-        }
-    }
-
-    public static String createKey() {
-        StringBuffer key = new StringBuffer();
-        Random rnd = new Random();
-
-        for (int i = 0; i < 8; i++) { // 인증코드 8자리
-            int index = rnd.nextInt(3); // 0~2 까지 랜덤
-
-            switch (index) {
-                case 0:
-                    key.append((char) ((int) (rnd.nextInt(26)) + 97));
-                    //  a~z  (ex. 1+97=98 => (char)98 = 'b')
-                    break;
-                case 1:
-                    key.append((char) ((int) (rnd.nextInt(26)) + 65));
-                    //  A~Z
-                    break;
-                case 2:
-                    key.append((rnd.nextInt(10)));
-                    // 0~9
-                    break;
-            }
-        }
-        return key.toString();
     }
 }

--- a/src/main/java/com/example/springbootboard/domain/emailauth/service/EmailServiceRedisImpl.java
+++ b/src/main/java/com/example/springbootboard/domain/emailauth/service/EmailServiceRedisImpl.java
@@ -3,30 +3,32 @@ package com.example.springbootboard.domain.emailauth.service;
 import com.example.springbootboard.domain.users.dto.UserEmailRequestDTO;
 import com.example.springbootboard.utils.RedisStringUtil;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Primary;
-import org.springframework.mail.MailException;
-import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import javax.mail.Message.RecipientType;
-import javax.mail.internet.InternetAddress;
-import javax.mail.internet.MimeMessage;
-import java.util.Random;
-
 @Service
-@Primary
+@Primary // 인터페이스에 여러 구현체가 있는경우 @Primary 어노테이션이 있는 빈을 주입한다.
 @RequiredArgsConstructor
 public class EmailServiceRedisImpl implements EmailService {
 
-    private final JavaMailSender emailSender;
     private final RedisStringUtil redisUtil;
+    private final EmailUtils emailUtils;
 
-    @Value("${AdminMail.id}")
-    private String id;
-    @Value("${AdminMail.password}")
-    private String password;
+    @Override
+    @Transactional
+    public void sendSimpleMessage(UserEmailRequestDTO userEmailRequestDTO) throws Exception {
+        String newAuthCode = emailUtils.createAuthCode();
+        String userEmail = userEmailRequestDTO.getUserEmail();
+
+        // Redis TTL 과 화면단 타이머가 5초 차이 발생 -> duration +5초 
+        boolean hasSetNewAuthCode = redisUtil.setDataIfAbsentExpire(userEmail, newAuthCode, (long) (5 * 60) + 5);
+        if (hasSetNewAuthCode) {
+            emailUtils.sendMail(userEmail, newAuthCode);
+            return;
+        }
+        System.out.println("이미 인증코드 발송이 된 메일입니다.");
+    }
 
     @Override
     @Transactional
@@ -35,72 +37,5 @@ public class EmailServiceRedisImpl implements EmailService {
         String storedAuthCode = redisUtil.getData(userEmailRequestDTO.getUserEmail());
 
         return authCode.equals(storedAuthCode);
-    }
-
-    @Override
-    @Transactional
-    public void sendSimpleMessage(UserEmailRequestDTO userEmailRequestDTO) throws Exception {
-        String newAuthCode = createKey();
-        String userEmail = userEmailRequestDTO.getUserEmail();
-
-        // Redis TTL 과 화면단 타이머가 5초 차이 발생 -> duration +5초 
-        boolean hasSetNewAuthCode = redisUtil.setDataIfAbsentExpire(userEmail, newAuthCode, (long) (5 * 60) + 5);
-        if (hasSetNewAuthCode) {
-            sendMail(userEmail, newAuthCode);
-            return;
-        }
-        System.out.println("이미 인증코드 발송이 된 메일입니다.");
-    }
-
-    private void sendMail(String userEmail, String authCode) throws Exception {
-
-        String serviceName = "Spring-Boards";
-        String subject = serviceName + " 가입 인증 메일";
-        String text = "<div style='margin:20px;'>" +
-                "<h1> 안녕하세요 " + serviceName + " 입니다.</h1><br>" +
-                "<p>아래 코드를 복사해 입력해주세요<p><br>" +
-                "<p>감사합니다.<p><br>" +
-                "<div align='center' style='border:1px solid black); font-family:verdana');>" +
-                "<h3 style='color:blue);'>회원가입 인증 코드입니다.</h3>" +
-                "<div style='font-size:130%'>CODE : <strong>" + authCode + "</strong><div><br/></div>";
-
-        MimeMessage message = emailSender.createMimeMessage();
-        message.addRecipients(RecipientType.TO, userEmail);// 보내는 대상
-        message.setSubject(subject);// 제목
-        message.setText(text, "utf-8", "html");// 내용
-        message.setFrom(new InternetAddress(id, serviceName));// 보내는 사람
-
-        try {// 예외처리
-            emailSender.send(message);
-            System.out.println("생성된 AuthCode : " + authCode);
-        } catch (MailException es) {
-            es.printStackTrace();
-            throw new IllegalArgumentException();
-        }
-    }
-
-    public static String createKey() {
-        StringBuffer key = new StringBuffer();
-        Random rnd = new Random();
-
-        for (int i = 0; i < 8; i++) { // 인증코드 8자리
-            int index = rnd.nextInt(3); // 0~2 까지 랜덤
-
-            switch (index) {
-                case 0:
-                    key.append((char) ((int) (rnd.nextInt(26)) + 97));
-                    //  a~z  (ex. 1+97=98 => (char)98 = 'b')
-                    break;
-                case 1:
-                    key.append((char) ((int) (rnd.nextInt(26)) + 65));
-                    //  A~Z
-                    break;
-                case 2:
-                    key.append((rnd.nextInt(10)));
-                    // 0~9
-                    break;
-            }
-        }
-        return key.toString();
     }
 }

--- a/src/main/java/com/example/springbootboard/domain/emailauth/service/EmailUtils.java
+++ b/src/main/java/com/example/springbootboard/domain/emailauth/service/EmailUtils.java
@@ -1,0 +1,8 @@
+package com.example.springbootboard.domain.emailauth.service;
+
+public interface EmailUtils {
+
+    public void sendMail(String userEmail, String authCode) throws Exception;
+
+    public String createAuthCode();
+}

--- a/src/main/java/com/example/springbootboard/domain/emailauth/service/EmailUtilsImpl.java
+++ b/src/main/java/com/example/springbootboard/domain/emailauth/service/EmailUtilsImpl.java
@@ -1,0 +1,77 @@
+package com.example.springbootboard.domain.emailauth.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.mail.MailException;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+
+import javax.mail.Message;
+import javax.mail.internet.InternetAddress;
+import javax.mail.internet.MimeMessage;
+import java.util.Random;
+
+@RequiredArgsConstructor
+@Service
+public class EmailUtilsImpl implements EmailUtils {
+
+    private final JavaMailSender emailSender;
+
+    @Value("${AdminMail.id}")
+    private String id;
+
+    @Value("${AdminMail.password}")
+    private String password;
+
+    public void sendMail(String userEmail, String authCode) throws Exception {
+
+        String serviceName = "Spring-Boards";
+        String subject = serviceName + " 가입 인증 메일";
+        String text = "<div style='margin:20px;'>" +
+                "<h1> 안녕하세요 " + serviceName + " 입니다.</h1><br>" +
+                "<p>아래 코드를 복사해 입력해주세요<p><br>" +
+                "<p>감사합니다.<p><br>" +
+                "<div align='center' style='border:1px solid black); font-family:verdana');>" +
+                "<h3 style='color:blue);'>회원가입 인증 코드입니다.</h3>" +
+                "<div style='font-size:130%'>CODE : <strong>" + authCode + "</strong><div><br/></div>";
+
+        MimeMessage message = emailSender.createMimeMessage();
+        message.addRecipients(Message.RecipientType.TO, userEmail);// 보내는 대상
+        message.setSubject(subject);// 제목
+        message.setText(text, "utf-8", "html");// 내용
+        message.setFrom(new InternetAddress(id, serviceName));// 보내는 사람
+
+        try {// 예외처리
+            emailSender.send(message);
+            System.out.println("생성된 AuthCode : " + authCode);
+        } catch (MailException es) {
+            es.printStackTrace();
+            throw new IllegalArgumentException();
+        }
+    }
+
+    public String createAuthCode() {
+        StringBuffer key = new StringBuffer();
+        Random rnd = new Random();
+
+        for (int i = 0; i < 8; i++) { // 인증코드 8자리
+            int index = rnd.nextInt(3); // 0~2 까지 랜덤
+
+            switch (index) {
+                case 0:
+                    key.append((char) ((int) (rnd.nextInt(26)) + 97));
+                    //  a~z  (ex. 1+97=98 => (char)98 = 'b')
+                    break;
+                case 1:
+                    key.append((char) ((int) (rnd.nextInt(26)) + 65));
+                    //  A~Z
+                    break;
+                case 2:
+                    key.append((rnd.nextInt(10)));
+                    // 0~9
+                    break;
+            }
+        }
+        return key.toString();
+    }
+}

--- a/src/test/java/com/example/springbootboard/domain/emailauth/service/EmailServiceImplTest.java
+++ b/src/test/java/com/example/springbootboard/domain/emailauth/service/EmailServiceImplTest.java
@@ -1,0 +1,82 @@
+package com.example.springbootboard.domain.emailauth.service;
+
+import com.example.springbootboard.domain.emailauth.EmailAuthRepository;
+import com.example.springbootboard.domain.users.dto.UserEmailRequestDTO;
+import com.example.springbootboard.utils.RedisStringUtil;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+@SpringBootTest
+class EmailServiceImplTest {
+
+    @Autowired
+    private RedisStringUtil redisStringUtil;
+
+    @Autowired
+    EmailUtils emailUtils;
+
+    @Autowired
+    EmailAuthRepository emailAuthRepository;
+
+    @Autowired
+    EmailServiceRedisImpl emailService;
+
+    @Transactional
+    @Test
+    public void 인증메일_발송후_sendMail_메서드가_실행되면_패스() throws Exception {
+        // given
+        /**
+         * 1) Testing 시 실제 Email 전송은 되지 않았으면 좋겠다고 생각했다. 
+         * 이를 위해 Mockito 를 활용해 Mock 객체로 메일 전송한 것 처럼 Test 진행이 가능했다.
+         * 2) mockEmailUtils 내부에 createAuthCode() 메서드를 활용해 authCode를 만드는 부분이 있었다.
+         * 해당 return 값을 redis 에 set 해주는 코드가 있었는데,
+         * redis 에 null 값을 set 하려니 IllegalArgumentException 이 발생하며 TEST 진행이 안되었다.
+         * 이에 when() 메서드를 활용해 createAuthCode()의 return 값을 stubbing 해주었고, 
+         * 해당 방법을 통해 원하는 Test 를 진행할 수 있었다.
+         */
+        EmailUtils mockEmailUtils = mock(EmailUtils.class);
+        when(mockEmailUtils.createAuthCode()).thenReturn("testAuthCode");
+
+        String authCode = mockEmailUtils.createAuthCode();
+        String userEmail = "test@test.com";
+        EmailServiceRedisImpl emailServiceRedis = new EmailServiceRedisImpl(redisStringUtil, mockEmailUtils);
+        UserEmailRequestDTO userEmailRequest = UserEmailRequestDTO.builder()
+                .authCode(authCode)
+                .userEmail(userEmail)
+                .build();
+
+        // when
+        emailServiceRedis.sendSimpleMessage(userEmailRequest);
+
+        // then
+        verify(mockEmailUtils).sendMail(userEmail, authCode);
+    }
+
+    @Transactional
+    @Test
+    public void 인증코드가_같으면_isVerified_true() throws Exception {
+        // given
+        EmailUtils mockEmailUtils = mock(EmailUtils.class);
+        when(mockEmailUtils.createAuthCode()).thenReturn("testAuthCode");
+
+        EmailServiceRedisImpl emailServiceRedis = new EmailServiceRedisImpl(redisStringUtil, mockEmailUtils);
+        String authCode = mockEmailUtils.createAuthCode();
+        String userEmail = "test@test.com";
+        UserEmailRequestDTO userEmailRequest = UserEmailRequestDTO.builder()
+                .userEmail(userEmail)
+                .authCode(authCode)
+                .build();
+        emailServiceRedis.sendSimpleMessage(userEmailRequest);
+
+        // when
+        boolean isExists = emailService.isVerifiedCode(userEmailRequest);
+        
+        // then
+        assertThat(isExists).isTrue();
+    }
+}


### PR DESCRIPTION
### 코드 작성 이유
DRY !!
<br>

### 상세 사항
- EmailService 내부의 `createAuthCode()`, `sendMail()` 로직을 EmailUtilsImpl로 분리
- TestCode 작성 시 Mockito 활용하여 메일 발송 없이 Test 진행되도록 작성
<br>

### 참고 사항
- Mockito의 when() 메서드를 활용해 stubbing (mock객체의 행동 정의) 가능함을 배움
<br>

### 다음 작업

<br>

#### CheckList

- [ ] Test Coverage 80%
- [x] 코딩 컨벤션 준수
- [x] 커밋 컨벤션 준수
